### PR TITLE
replace next lint with biome

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "biome lint",
     "test": "vitest",
     "preinstall": "npx only-allow pnpm"
   },


### PR DESCRIPTION
next lintはNext.js 15.5で非推奨化
[https://nextjs.org/blog/next-15-5]()